### PR TITLE
Allow app config overrides and disabling

### DIFF
--- a/config/example-config.json
+++ b/config/example-config.json
@@ -38,5 +38,7 @@
 	"iterations": 50000,
 	"dev": true,
 	"log": "/var/log/membership.log",
-	"logStdout": false
+	"logStdout": false,
+	"appOverrides": {
+	}
 }


### PR DESCRIPTION
This PR adds two things:
- Ability to disable apps in their config
- Allow app configs to be overridden in the system's main config file.

The primary use case imagined for this would be to allow different forks of the same system to run different apps, but any config option can be overridden (e.g. priority etc.)