### PR TITLE
Allow admin to update multi-field address

### DIFF
--- a/apps/members/schemas.json
+++ b/apps/members/schemas.json
@@ -1,0 +1,57 @@
+{
+	"updateProfileSchema": {
+		"body": {
+			"type": "object",
+			"required": ["email", "firstname", "lastname", "delivery_optin"],
+			"properties": {
+				"email": {
+					"type": "string",
+					"format": "email"
+				},
+				"firstname": {
+					"type": "string",
+					"minLength": 1
+				},
+				"lastname": {
+					"type": "string",
+					"minLength": 1
+				},
+				"delivery_optin": {
+					"type": "boolean"
+				}
+			},
+			"oneOf": [
+				{
+					"required": ["delivery_line1", "delivery_city", "delivery_postcode"],
+					"properties": {
+						"delivery_optin": {
+							"const": true
+						},
+						"delivery_line1": {
+							"type": "string",
+							"minLength": 1
+						},
+						"delivery_line2": {
+							"type": "string"
+						},
+						"delivery_city": {
+							"type": "string",
+							"minLength": 1
+						},
+						"delivery_postcode": {
+							"type": "string",
+							"format": "postcode"
+						}
+					}
+				},
+				{
+					"properties": {
+						"delivery_optin": {
+							"const": false
+						}
+					}
+				}
+			]
+		}
+	}
+}

--- a/apps/members/views/partials/sidebar.pug
+++ b/apps/members/views/partials/sidebar.pug
@@ -6,5 +6,4 @@ ul.nav.nav-pills.nav-stacked
 		li( class=( page == 'tag' ? 'active' : '' ) ): a( href='/members/' + member.uuid + '/tag' ) Tag
 		if ( member.otp.activated )
 			li( class=( page == '2fa' ? 'active' : '' ) ): a( href='/members/' + member.uuid + '/2fa' ) 2FA
-		li( class=( page == 'gocardless' ? 'active' : '' ) ): a( href='/members/' + member.uuid + '/gocardless' ) GoCardless
 	li( class=( page == 'permissions' ? 'active' : '' ) ): a( href='/members/' + member.uuid + '/permissions' ) Permissions

--- a/apps/members/views/update.pug
+++ b/apps/members/views/update.pug
@@ -15,13 +15,24 @@ block contents
 
 				h3 Account details
 
-				+input( 'email', 'Email', 'email', { value: member.email, required: true, helpblock: "This will change the users login details.", left: 3, right: 4 } )
+				+input( 'email', 'Email', 'email', { value: member.email, required: true, left: 3, right: 4, readonly: true } )
 				+input( 'text', 'First Name', 'firstname', { value: member.firstname, required: true, left: 3, right: 4 } )
 				+input( 'text', 'Last Name', 'lastname', { value: member.lastname, required: true, left: 3, right: 4 } )
 
 				h3 Delivery details
+				.form-group
+					label.col-md-3.control-label Delivery opt in
+					.col-md-4
+						label.radio-inline
+							input(type='radio', name='delivery_optin', value='true', checked=member.delivery_optin)
+							| Yes
+						| 
+						label.radio-inline
+							input(type='radio', name='delivery_optin', value='false', checked=!member.delivery_optin)
+							| No
+
 				+input( 'text', 'Address line 1', 'delivery_line1', { value: member.delivery_address.line1, left: 3, right: 4 } )
 				+input( 'text', 'Address line 2', 'delivery_line2', { value: member.delivery_address.line2, left: 3, right: 4 } )
 				+input( 'text', 'City/town', 'delivery_city', { value: member.delivery_address.city, left: 3, right: 4 } )
 				+input( 'text', 'Postcode', 'delivery_postcode', { value: member.delivery_address.postcode, left: 3, right: 4 } )
-				+form_button( 'Update', 'primary' )
+				+form_button( 'Update', 'primary', {left: 3} )

--- a/tools/import/old-data.js
+++ b/tools/import/old-data.js
@@ -33,13 +33,16 @@ async function loadData(file) {
 			};
 		});
 
-	const wpFile = Papa.parse(fs.readFileSync(file).toString(), {
-		header: true,
-		skipEmptyLines: true
-	});
-	const wpOverrides = wpFile.data.map(row => ({...row, type: 'wp'}));
-
-	return [...wpOverrides, ...gcOverrides];
+	if (file) {
+		const wpFile = Papa.parse(fs.readFileSync(file).toString(), {
+			header: true,
+			skipEmptyLines: true
+		});
+		const wpOverrides = wpFile.data.map(row => ({...row, type: 'wp'}));
+		return [...wpOverrides, ...gcOverrides];
+	} else {
+		return gcOverrides;
+	}
 }
 
 async function syncData(overrides) {
@@ -71,11 +74,6 @@ async function syncData(overrides) {
 			console.log(error.message);
 		}
 	}
-}
-
-if (!fs.existsSync(process.argv[2])) {
-  console.error('Argument is not a valid file');
-  process.exit(1);
 }
 
 loadData(process.argv[2])


### PR DESCRIPTION
This PR allows admins to update the new multi-field delivery address data. It also updates the import old data tool to not require a CSV of old data. This will allow us to start using the system for administration while customer signups are still happening on the old form.